### PR TITLE
Add whisper server and HTML client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module example.com/hello
+
+go 1.23.8

--- a/index.html
+++ b/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Whisper Recorder</title>
+</head>
+<body>
+<button id="start">Start Recording</button>
+<button id="stop" disabled>Stop Recording</button>
+<pre id="result"></pre>
+<script>
+let mediaRecorder;
+let chunks = [];
+
+const startBtn = document.getElementById('start');
+const stopBtn = document.getElementById('stop');
+const result = document.getElementById('result');
+
+startBtn.onclick = async () => {
+  const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  mediaRecorder = new MediaRecorder(stream);
+  mediaRecorder.ondataavailable = e => {
+    if (e.data.size > 0) chunks.push(e.data);
+  };
+  mediaRecorder.onstop = sendData;
+  mediaRecorder.start();
+  startBtn.disabled = true;
+  stopBtn.disabled = false;
+};
+
+stopBtn.onclick = () => {
+  mediaRecorder.stop();
+  startBtn.disabled = false;
+  stopBtn.disabled = true;
+};
+
+async function sendData() {
+  const blob = new Blob(chunks, { type: 'audio/webm' });
+  chunks = [];
+  const formData = new FormData();
+  formData.append('audio', blob, 'recording.webm');
+  const resp = await fetch('/transcribe', { method: 'POST', body: formData });
+  const data = await resp.json();
+  result.textContent = data.text;
+}
+</script>
+</body>
+</html>

--- a/main.go
+++ b/main.go
@@ -1,5 +1,53 @@
 package main
 
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+)
+
 func main() {
-    println("hello!")
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, "index.html")
+	})
+	http.HandleFunc("/transcribe", transcribeHandler)
+	http.ListenAndServe(":8080", nil)
+}
+
+func transcribeHandler(w http.ResponseWriter, r *http.Request) {
+	err := r.ParseMultipartForm(10 << 20)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	file, _, err := r.FormFile("audio")
+	if err != nil {
+		http.Error(w, "failed to get audio: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	defer file.Close()
+
+	tmp, err := os.CreateTemp("", "recording-*.webm")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := io.Copy(tmp, file); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	tmp.Close()
+
+	cmd := exec.Command("whisper", tmp.Name(), "--model", "base")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		http.Error(w, "whisper error: "+err.Error()+": "+string(out), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"text": string(out)})
 }


### PR DESCRIPTION
## Summary
- implement a simple Go HTTP server that accepts audio, calls `whisper` and returns the text
- add an HTML5 page that records audio and posts it to the server
- set up go.mod for the server

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_b_683d4fbac918832e9f8f9fb287a1e8ff